### PR TITLE
Fix hover state of SubNavigation link to display pointer cursor

### DIFF
--- a/src/components/sub-navigation/_SubNavigation.scss
+++ b/src/components/sub-navigation/_SubNavigation.scss
@@ -55,6 +55,7 @@ $sub-navigation-breakpoint: 40.0625em;
   &:hover {
     color: $tab-link-color;
     position: relative;
+    cursor: pointer;
 
     &::before {
       background-color: #000;


### PR DESCRIPTION
The hover state of the SubNavigation links currently doesn't display a pointer cursor. This quick fix ensures that it does.