### PR TITLE
Feature - Reactify Tag Component

### DIFF
--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -2,6 +2,6 @@ import * as index from '../index';
 
 describe('Index', () => {
   it('contains all expected elements', () => {
-    expect(Object.keys(index)).toEqual(['SubNavigation']);
+    expect(Object.keys(index)).toEqual(['SubNavigation', 'Tag']);
   });
 });

--- a/src/all.scss
+++ b/src/all.scss
@@ -4,5 +4,5 @@
 // SubNavigation Component
 @import './components/sub-navigation/SubNavigation';
 
-// Tag Styling
-@import './styles/tag';
+// Tag Component
+@import './components/tag/Tag';

--- a/src/components.scss
+++ b/src/components.scss
@@ -1,5 +1,5 @@
 // SubNavigation Component
 @import './components/sub-navigation/SubNavigation';
 
-// Tag Styling
-@import './styles/tag';
+// Tag Component
+@import './components/tag/Tag';

--- a/src/components/tag/Tag.tsx
+++ b/src/components/tag/Tag.tsx
@@ -1,0 +1,27 @@
+import React, { HTMLProps } from 'react';
+import classNames from 'classnames';
+
+type TagColours =
+  | 'white'
+  | 'grey'
+  | 'green'
+  | 'aqua-green'
+  | 'blue'
+  | 'purple'
+  | 'pink'
+  | 'red'
+  | 'orange'
+  | 'yellow';
+
+interface TagProps extends HTMLProps<HTMLSpanElement> {
+  color?: TagColours;
+}
+
+const Tag: React.FC<TagProps> = ({ className, color, ...rest }) => (
+  <span
+    className={classNames('nhsuk-tag', { [`nhsuk-tag--${color}`]: color }, className)}
+    {...rest}
+  />
+);
+
+export default Tag;

--- a/src/components/tag/_Tag.scss
+++ b/src/components/tag/_Tag.scss
@@ -1,5 +1,4 @@
-@import 'variables';
-@import 'core';
+@import '../../styles/variables';
 
 /* ==========================================================================
    #TAG

--- a/src/components/tag/__tests__/Tag.test.tsx
+++ b/src/components/tag/__tests__/Tag.test.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import Tag from '..';
+
+describe('Tag', () => {
+  it('matches snapshot', () => {
+    const component = shallow(<Tag>Tag</Tag>);
+    expect(component).toMatchSnapshot();
+    expect(component.text()).toBe('Tag');
+    component.unmount();
+  });
+
+  it('applies classes', () => {
+    const unstyledTag = shallow(<Tag />);
+    const colouredTag = shallow(<Tag color="aqua-green" />);
+    const customTag = shallow(<Tag color="aqua-green" className="customClassName" />);
+
+    expect(unstyledTag.render().prop('class')).toBe('nhsuk-tag');
+    expect(colouredTag.render().prop('class')).toBe('nhsuk-tag nhsuk-tag--aqua-green');
+    expect(customTag.render().prop('class')).toBe(
+      'nhsuk-tag nhsuk-tag--aqua-green customClassName',
+    );
+    unstyledTag.unmount();
+    colouredTag.unmount();
+    customTag.unmount();
+  });
+});

--- a/src/components/tag/__tests__/__snapshots__/Tag.test.tsx.snap
+++ b/src/components/tag/__tests__/__snapshots__/Tag.test.tsx.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Tag matches snapshot 1`] = `
+<span
+  className="nhsuk-tag"
+>
+  Tag
+</span>
+`;

--- a/src/components/tag/index.ts
+++ b/src/components/tag/index.ts
@@ -1,0 +1,3 @@
+import Tag from './Tag';
+
+export default Tag;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,2 @@
-// Remove the next line once there is a second export.
-// eslint-disable-next-line import/prefer-default-export
 export { default as SubNavigation } from './components/sub-navigation';
+export { default as Tag } from './components/tag';

--- a/src/styles/_variables.scss
+++ b/src/styles/_variables.scss
@@ -1,6 +1,7 @@
 // Settings
 @import '~nhsuk-frontend/packages/core/settings/all';
 @import '~nhsuk-frontend/packages/core/settings/colours';
+@import '~nhsuk-frontend/packages/core/tools/sass-mq';
 @import '~nhsuk-frontend/packages/core/tools/typography';
 
 $color_nhsuk-pink: #ae2573;

--- a/src/styles/_variables.scss
+++ b/src/styles/_variables.scss
@@ -1,5 +1,6 @@
 // Settings
 @import '~nhsuk-frontend/packages/core/settings/all';
 @import '~nhsuk-frontend/packages/core/settings/colours';
+@import '~nhsuk-frontend/packages/core/tools/typography';
 
 $color_nhsuk-pink: #ae2573;

--- a/stories/Tag.stories.tsx
+++ b/stories/Tag.stories.tsx
@@ -1,34 +1,33 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
+import { Tag } from '../src';
 
 const stories = storiesOf('Tags', module);
 
-stories.add('Basic', () => {
-  return (
+stories
+  .add('Basic', () => (
     <div className="tag-demo">
-      <span className="nhsuk-tag">Standard</span>
-      <span className="nhsuk-tag">Done</span>
-      <span className="nhsuk-tag nhsuk-tag--white"> Started </span>
-      <span className="nhsuk-tag nhsuk-tag--grey"> Not Started </span>
-      <span className="nhsuk-tag nhsuk-tag--blue"> Ready to submit </span>
-      <span className="nhsuk-tag nhsuk-tag--red"> FP69 </span>
-      <span className="nhsuk-tag nhsuk-tag--orange"> Ceased - no cervix </span>
+      <Tag>Standard</Tag>
+      <Tag>Done</Tag>
+      <Tag color="white">Started</Tag>
+      <Tag color="grey">Not Started</Tag>
+      <Tag color="blue">Ready to submit</Tag>
+      <Tag color="red">FP69</Tag>
+      <Tag color="orange">Ceased - no cervix</Tag>
     </div>
-  );
-}).add('Colours', () => {
-  return (
+  ))
+  .add('Colours', () => (
     <div className="tag-demo">
-      <span className="nhsuk-tag">Standard</span>
-      <span className="nhsuk-tag nhsuk-tag--white"> Started </span>
-      <span className="nhsuk-tag nhsuk-tag--grey"> Not Started </span>
-      <span className="nhsuk-tag nhsuk-tag--green"> New </span>
-      <span className="nhsuk-tag nhsuk-tag--aqua-green"> Active </span>
-      <span className="nhsuk-tag nhsuk-tag--blue"> Pending </span>
-      <span className="nhsuk-tag nhsuk-tag--purple"> Received </span>
-      <span className="nhsuk-tag nhsuk-tag--pink"> Sent </span>
-      <span className="nhsuk-tag nhsuk-tag--red"> Rejected </span>
-      <span className="nhsuk-tag nhsuk-tag--orange"> Declined </span>
-      <span className="nhsuk-tag nhsuk-tag--yellow"> Delayed </span>
+      <Tag>Standard</Tag>
+      <Tag color="white">Started</Tag>
+      <Tag color="grey">Not Started</Tag>
+      <Tag color="green">New</Tag>
+      <Tag color="aqua-green">Active</Tag>
+      <Tag color="blue">Pending</Tag>
+      <Tag color="purple">Received</Tag>
+      <Tag color="pink">Sent</Tag>
+      <Tag color="red">Rejected</Tag>
+      <Tag color="orange">Declined</Tag>
+      <Tag color="yellow">Delayed</Tag>
     </div>
-  );
-});
+  ));


### PR DESCRIPTION
Related Issue: https://github.com/NHSDigital/nhsuk-react-components-extensions/issues/8

This adds the Tag component, with a discrete list of possible colours than can be passed using the `color` prop. 

As a note, I chose the `color` prop instead of the UK English `colour`, as `color` is already a valid HTML `<span>` prop, so it might get confusing if there is a valid `color` and `colour` prop.