### PR TITLE
Pass className to Tab component

### DIFF
--- a/src/components/tab-set/components/Tab.tsx
+++ b/src/components/tab-set/components/Tab.tsx
@@ -13,6 +13,7 @@ const Tab: React.FC<TabProps> = ({ className, active, disabled, empty, ...rest }
       { 'nhsuk-tab-set__tab--active': active },
       { 'nhsuk-tab-set__tab--disabled': disabled },
       { 'nhsuk-tab-set__tab--empty': empty },
+      className,
     )}
     {...rest}
   />


### PR DESCRIPTION
The `className` prop is pulled out from the props in the `TabSet.Tab` component, but is not passed to the `classNames` function so does not appear in the rendered component. This PR adds the className prop back to the function.