### PR TITLE
fix: Add Timeline styles to components exports

### DIFF
--- a/src/components.scss
+++ b/src/components.scss
@@ -9,3 +9,4 @@
 @import './components/tab-set/TabSet';
 @import './components/tooltip/Tooltip';
 @import './components/ribbon-link/RibbonLink';
+@import './components/timeline/Timeline';


### PR DESCRIPTION
Add missing Timeline styles import to `./components.scss`
Fix for issue #19