### PR TITLE
NCRS-3931 Close mobile menu on lost focus & fix aria toggling

### DIFF
--- a/src/components/header-with-logo/__tests__/HeaderWithLogo.test.tsx
+++ b/src/components/header-with-logo/__tests__/HeaderWithLogo.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { fireEvent, render } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import HeaderWithLogo from '../HeaderWithLogo';
 
 describe('The header component', () => {
@@ -127,23 +127,6 @@ describe('The header component', () => {
         expect(visuallyHiddenText?.nextSibling?.textContent).toBe(dropdownText ?? 'More');
       },
     );
-
-    it('Invokes the onClick prop when button is clicked', () => {
-      const clickFn = jest.fn();
-      const { container } = render(
-        <HeaderWithLogo>
-          <HeaderWithLogo.NavDropdownMenu onClick={clickFn}></HeaderWithLogo.NavDropdownMenu>
-        </HeaderWithLogo>,
-      );
-
-      const buttonElement = container.querySelector('.nhsuk-header__menu-toggle');
-
-      expect(clickFn).not.toHaveBeenCalled();
-
-      fireEvent.click(buttonElement!);
-
-      expect(clickFn).toHaveBeenCalledTimes(1);
-    });
   });
 
   describe('The NavItem component', () => {

--- a/src/components/header-with-logo/__tests__/__snapshots__/HeaderWithLogo.test.tsx.snap
+++ b/src/components/header-with-logo/__tests__/__snapshots__/HeaderWithLogo.test.tsx.snap
@@ -172,7 +172,6 @@ exports[`The header component Matches the snapshot 1`] = `
               class="nhsuk-mobile-menu-container"
             >
               <button
-                aria-expanded="false"
                 class="nhsuk-header__menu-toggle nhsuk-header__navigation-link"
               >
                 <span

--- a/src/components/header-with-logo/_headerWithLogo.scss
+++ b/src/components/header-with-logo/_headerWithLogo.scss
@@ -109,7 +109,6 @@
       right: 0;
       padding-right: 8px;
       border-radius: 0;
-      color: #212b32;
 
       // Chevron fixes
       .nhsuk-icon {

--- a/src/components/header-with-logo/_headerWithLogo.scss
+++ b/src/components/header-with-logo/_headerWithLogo.scss
@@ -56,7 +56,7 @@
   flex-shrink: 1;
   align-items: center;
   justify-content: flex-end;
-    
+
   .nhsuk-navigation {
     width: 100%;
     max-width: 100%;
@@ -109,6 +109,7 @@
       right: 0;
       padding-right: 8px;
       border-radius: 0;
+      color: #212b32;
 
       // Chevron fixes
       .nhsuk-icon {
@@ -117,9 +118,10 @@
         height: 24px;
         margin-left: 6px;
         transform: rotate(90deg);
+        fill: inherit;
       }
 
-      &[aria-expanded='true'] {
+      &--expanded {
         .nhsuk-icon {
           transform: rotate(-90deg);
         }

--- a/src/components/header-with-logo/components/LocalNavDropdownMenu.tsx
+++ b/src/components/header-with-logo/components/LocalNavDropdownMenu.tsx
@@ -1,5 +1,4 @@
-import React, { FC, HTMLProps, useContext, useEffect, MouseEvent } from 'react';
-import HeaderContext, { IHeaderContext } from '../HeaderContext';
+import React, { FC, HTMLProps } from 'react';
 import { ChevronDownIcon } from './LocalChevronDown';
 export interface NavDropdownMenuProps extends HTMLProps<HTMLButtonElement> {
   type?: 'button' | 'submit' | 'reset';
@@ -7,27 +6,11 @@ export interface NavDropdownMenuProps extends HTMLProps<HTMLButtonElement> {
 }
 
 const NavMenuDropdown: FC<NavDropdownMenuProps> = ({ onClick, dropdownText = 'More', ...rest }) => {
-  const { setMenuToggle, toggleMenu, menuOpen } = useContext<IHeaderContext>(HeaderContext);
-
-  const onToggleClick = (e: MouseEvent<HTMLButtonElement>) => {
-    toggleMenu();
-
-    if (onClick) {
-      onClick(e);
-    }
-  };
-
-  useEffect(() => {
-    setMenuToggle(true);
-    return () => setMenuToggle(false);
-  }, []);
 
   return (
     <li className="nhsuk-mobile-menu-container">
       <button
         className="nhsuk-header__menu-toggle nhsuk-header__navigation-link "
-        aria-expanded={menuOpen ? 'true' : 'false'}
-        onClick={onToggleClick}
         {...rest}
       >
         <span className="nhsuk-u-visually-hidden">Browse</span>

--- a/src/components/header-with-logo/components/LocalNavDropdownMenu.tsx
+++ b/src/components/header-with-logo/components/LocalNavDropdownMenu.tsx
@@ -1,4 +1,5 @@
-import React, { FC, HTMLProps } from 'react';
+import React, { FC, HTMLProps, useContext, useEffect } from 'react';
+import HeaderContext, { IHeaderContext } from '../HeaderContext';
 import { ChevronDownIcon } from './LocalChevronDown';
 export interface NavDropdownMenuProps extends HTMLProps<HTMLButtonElement> {
   type?: 'button' | 'submit' | 'reset';
@@ -6,6 +7,12 @@ export interface NavDropdownMenuProps extends HTMLProps<HTMLButtonElement> {
 }
 
 const NavMenuDropdown: FC<NavDropdownMenuProps> = ({ onClick, dropdownText = 'More', ...rest }) => {
+  const { setMenuToggle } = useContext<IHeaderContext>(HeaderContext);
+
+  useEffect(() => {
+    setMenuToggle(true);
+    return () => setMenuToggle(false);
+  }, []);
 
   return (
     <li className="nhsuk-mobile-menu-container">

--- a/src/components/header-with-logo/header.js
+++ b/src/components/header-with-logo/header.js
@@ -2,10 +2,6 @@
  * Lifted from nhsuk-frontend and brought into this repo to enable compilation to CJS if required
  * See Github issue https://github.com/nhsuk/nhsuk-frontend/issues/937
  */
-
-import { resourceUsage } from "process";
-
-
 class Header {
   constructor() {
     this.menuIsOpen = false;
@@ -97,6 +93,7 @@ class Header {
     this.menuIsOpen = false;
     this.mobileMenu.classList.add('nhsuk-header__drop-down--hidden');
     this.navigation.style.marginBottom = 0;
+    this.mobileMenuToggleButton.classList.remove('nhsuk-header__menu-toggle--expanded');
     this.mobileMenuToggleButton.setAttribute('aria-expanded', 'false');
     document.removeEventListener('keydown', this.handleEscapeKey.bind(this));
   }
@@ -109,7 +106,7 @@ class Header {
    *
    */
   handleEscapeKey(e) {
-    if (e.key === 'Escape') {
+    if (e.key === 'Escape' && this.menuIsOpen) {
       this.closeMobileMenu();
       this.mobileMenuToggleButton.focus();
     }
@@ -125,13 +122,12 @@ class Header {
    */
   onBlur(e) {
     const grandchildren = this.mobileMenu.querySelectorAll('li a');
-    const mobileMenuIsClosed = this.mobileMenu.classList.contains('nhsuk-header__drop-down--hidden');
     // Checks the current link even qualifies
     const currentFocusIsInDropdown = Array.from(grandchildren).includes(e.currentTarget);
     const currentFocusIsToggleOrSubLink = e.currentTarget.classList.contains('nhsuk-header__menu-toggle') || currentFocusIsInDropdown
 
     // If the menu isn't open, or the old link isn't one of the toggles or sub links, return;
-    if (mobileMenuIsClosed || !currentFocusIsToggleOrSubLink) {
+    if (!this.menuIsOpen || !currentFocusIsToggleOrSubLink) {
       return;
     }
 
@@ -163,6 +159,7 @@ class Header {
     this.mobileMenu.classList.remove('nhsuk-header__drop-down--hidden');
     const marginBody = this.mobileMenu.offsetHeight;
     this.navigation.style.marginBottom = `${marginBody}px`;
+    this.mobileMenuToggleButton.classList.add('nhsuk-header__menu-toggle--expanded');
     this.mobileMenuToggleButton.setAttribute('aria-expanded', 'true');
 
     // add event listener for esc key to close menu


### PR DESCRIPTION
Added functionality so the HeaderWithLogo dropdown menu closes on lost focus. Also removed duplicated functionality where the toggle's aria label was set via the context, not the header.js. I've also added a toggled class so chevron styling isn't reliant on pseudo classes.